### PR TITLE
feat!: accept a list of GPG public keys (gpg_public_keys)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ module "debian_repo" {
   environment         = "production"
   repository_codename = "noble"
   domain_name         = "packages.example.com"
-  gpg_public_key      = file("./files/DEB-GPG-KEY-my-company")
+  gpg_public_keys     = [
+    file("./files/DEB-GPG-KEY-my-company")
+  ]
   gpg_sign_with       = "packager@example.com"
   zone_id             = data.aws_route53_zone.example.id
 }
@@ -156,8 +158,8 @@ This project is licensed under the Apache License 2.0 -- see [LICENSE](LICENSE) 
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | S3 bucket name for the repository. | `string` | n/a | yes |
 | <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | Domain name where the repository will be available. | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment name (e.g., development, staging, production). Used for resource tagging and identification. | `string` | n/a | yes |
-| <a name="input_gpg_public_key"></a> [gpg\_public\_key](#input\_gpg\_public\_key) | Content of the GPG public key used for signing the repository. Note, you'll have to upload the key manually or with 'ih-s3-reprepro ... set-secret-value packager-key-focal ~/packager-key-focal' | `string` | n/a | yes |
-| <a name="input_gpg_sign_with"></a> [gpg\_sign\_with](#input\_gpg\_sign\_with) | Email of a packager user. | `string` | n/a | yes |
+| <a name="input_gpg_public_keys"></a> [gpg\_public\_keys](#input\_gpg\_public\_keys) | Armored GPG public keys to publish for repository verification. They are concatenated into the<br/>single published key object (DEB-GPG-KEY-<domain\_name>); apt trusts a Release signed by any key<br/>in the resulting keyring. During a signing-key rotation this holds both the outgoing and<br/>incoming keys so clients trust a Release signed by either. Each list element is a full armored<br/>public key block.<br/><br/>The private signing key(s) are uploaded out-of-band with<br/>'ih-secrets set packager-key-<codename> ~/packager-key-<codename>'. | `list(string)` | n/a | yes |
+| <a name="input_gpg_sign_with"></a> [gpg\_sign\_with](#input\_gpg\_sign\_with) | Signing key identifier(s) for reprepro's SignWith in conf/distributions. Accepts a packager<br/>email or one or more space-separated GPG key IDs / fingerprints. During a key rotation, set this<br/>to both the outgoing and incoming key IDs to dual-sign the repository. | `string` | n/a | yes |
 | <a name="input_http_auth_password"></a> [http\_auth\_password](#input\_http\_auth\_password) | Password for HTTP basic authentication. | `string` | `null` | no |
 | <a name="input_http_auth_user"></a> [http\_auth\_user](#input\_http\_auth\_user) | Username for HTTP basic authentication. If not specified, the authentication isn't enabled. | `string` | `null` | no |
 | <a name="input_index_body"></a> [index\_body](#input\_index\_body) | Content of a body tag in index.html. | `string` | `"Stay tuned!"` | no |

--- a/bucket.tf
+++ b/bucket.tf
@@ -97,7 +97,7 @@ resource "aws_s3_object" "index-html" {
 resource "aws_s3_object" "deb-gpg-public-key" {
   bucket       = module.repo_bucket.bucket_name
   key          = "DEB-GPG-KEY-${var.domain_name}"
-  content      = var.gpg_public_key
+  content      = join("\n", var.gpg_public_keys)
   content_type = "text/plain"
   tags         = local.default_module_tags
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,8 +9,8 @@ This page documents all available configuration options.
 | `bucket_name` | S3 bucket name for the repository |
 | `domain_name` | Domain name where the repository will be available |
 | `environment` | Environment name (e.g., "production") |
-| `gpg_public_key` | Content of the GPG public key for signing |
-| `gpg_sign_with` | Email address of the GPG signing key |
+| `gpg_public_keys` | Armored GPG public key(s) to publish; concatenated into one keyring so clients trust a Release signed by any of them |
+| `gpg_sign_with` | Signing key identifier(s): a packager email or space-separated GPG key IDs / fingerprints |
 | `repository_codename` | Distribution codename (e.g., "noble", "jammy") |
 | `zone_id` | Route53 zone ID for the parent domain |
 
@@ -84,8 +84,8 @@ module "debian_repo" {
 
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
-| `gpg_public_key` | string | (required) | Armored GPG public key content |
-| `gpg_sign_with` | string | (required) | Email of the signing key |
+| `gpg_public_keys` | list(string) | (required) | Armored GPG public keys to publish (concatenated into one keyring bundle) |
+| `gpg_sign_with` | string | (required) | Packager email or space-separated GPG key IDs to sign with |
 | `signing_key_readers` | list(string) | `null` | Role ARNs that can read the GPG key |
 | `signing_key_writers` | list(string) | `null` | Role ARNs that can write/rotate the GPG key |
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -19,7 +19,9 @@ module "oss_repo" {
   environment         = "production"
   repository_codename = "noble"
   domain_name         = "packages.example.com"
-  gpg_public_key      = file("./files/DEB-GPG-KEY-my-company")
+  gpg_public_keys     = [
+    file("./files/DEB-GPG-KEY-my-company")
+  ]
   gpg_sign_with       = "packager@example.com"
   zone_id             = data.aws_route53_zone.example.id
 }
@@ -42,7 +44,9 @@ module "private_repo" {
   environment         = "production"
   repository_codename = "noble"
   domain_name         = "internal-packages.example.com"
-  gpg_public_key      = file("./files/DEB-GPG-KEY-my-company")
+  gpg_public_keys     = [
+    file("./files/DEB-GPG-KEY-my-company")
+  ]
   gpg_sign_with       = "packager@example.com"
   zone_id             = data.aws_route53_zone.example.id
 
@@ -68,7 +72,9 @@ module "repo_noble" {
   environment         = "production"
   repository_codename = "noble"
   domain_name         = "noble.packages.example.com"
-  gpg_public_key      = file("./files/DEB-GPG-KEY-my-company")
+  gpg_public_keys     = [
+    file("./files/DEB-GPG-KEY-my-company")
+  ]
   gpg_sign_with       = "packager@example.com"
   zone_id             = data.aws_route53_zone.example.id
 }
@@ -85,7 +91,9 @@ module "repo_jammy" {
   environment         = "production"
   repository_codename = "jammy"
   domain_name         = "jammy.packages.example.com"
-  gpg_public_key      = file("./files/DEB-GPG-KEY-my-company")
+  gpg_public_keys     = [
+    file("./files/DEB-GPG-KEY-my-company")
+  ]
   gpg_sign_with       = "packager@example.com"
   zone_id             = data.aws_route53_zone.example.id
 }
@@ -108,7 +116,9 @@ module "debian_repo" {
   environment         = "production"
   repository_codename = "noble"
   domain_name         = "packages.example.com"
-  gpg_public_key      = file("./files/DEB-GPG-KEY-my-company")
+  gpg_public_keys     = [
+    file("./files/DEB-GPG-KEY-my-company")
+  ]
   gpg_sign_with       = "packager@example.com"
   zone_id             = data.aws_route53_zone.example.id
 
@@ -149,7 +159,9 @@ module "debian_repo" {
   environment         = "production"
   repository_codename = "noble"
   domain_name         = "packages.example.com"
-  gpg_public_key      = file("./files/DEB-GPG-KEY-my-company")
+  gpg_public_keys     = [
+    file("./files/DEB-GPG-KEY-my-company")
+  ]
   gpg_sign_with       = "packager@example.com"
   zone_id             = data.aws_route53_zone.example.id
   architectures       = ["amd64", "arm64"]
@@ -173,7 +185,9 @@ module "debian_repo" {
   environment         = "production"
   repository_codename = "noble"
   domain_name         = "packages.example.com"
-  gpg_public_key      = file("./files/DEB-GPG-KEY-my-company")
+  gpg_public_keys     = [
+    file("./files/DEB-GPG-KEY-my-company")
+  ]
   gpg_sign_with       = "packager@example.com"
   zone_id             = data.aws_route53_zone.example.id
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -68,7 +68,9 @@ module "debian_repo" {
   environment         = "production"
   repository_codename = "noble"
   domain_name         = "packages.example.com"
-  gpg_public_key      = file("./files/DEB-GPG-KEY-my-company")
+  gpg_public_keys     = [
+    file("./files/DEB-GPG-KEY-my-company")
+  ]
   gpg_sign_with       = "packager@example.com"
   zone_id             = data.aws_route53_zone.example.id
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,7 +46,9 @@ module "debian_repo" {
   environment         = "production"
   repository_codename = "noble"
   domain_name         = "packages.example.com"
-  gpg_public_key      = file("./files/DEB-GPG-KEY-my-company")
+  gpg_public_keys     = [
+    file("./files/DEB-GPG-KEY-my-company")
+  ]
   gpg_sign_with       = "packager@example.com"
   zone_id             = data.aws_route53_zone.example.id
 }

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -23,9 +23,11 @@ module "debian_repo" {
   environment         = "production"
   repository_codename = "noble"
   domain_name         = "packages.example.com"
-  gpg_public_key      = file("${path.module}/files/DEB-GPG-KEY-example")
-  gpg_sign_with       = "packager@example.com"
-  zone_id             = data.aws_route53_zone.example.id
+  gpg_public_keys = [
+    file("${path.module}/files/DEB-GPG-KEY-example")
+  ]
+  gpg_sign_with = "packager@example.com"
+  zone_id       = data.aws_route53_zone.example.id
 }
 
 output "repo_url" {

--- a/test_data/test_module/main.tf
+++ b/test_data/test_module/main.tf
@@ -6,10 +6,12 @@ module "test" {
     aws.ue1 = aws.aws-us-east-1
   }
 
-  source                = "../../"
-  bucket_name           = "infrahouse-${random_pet.bucket_suffix.id}"
-  domain_name           = "debian-repo-test.${data.aws_route53_zone.cicd.name}"
-  gpg_public_key        = file("${path.module}/files/DEB-GPG-KEY-infrahouse-${var.ubuntu_codename}")
+  source      = "../../"
+  bucket_name = "infrahouse-${random_pet.bucket_suffix.id}"
+  domain_name = "debian-repo-test.${data.aws_route53_zone.cicd.name}"
+  gpg_public_keys = [
+    file("${path.module}/files/DEB-GPG-KEY-infrahouse-${var.ubuntu_codename}")
+  ]
   gpg_sign_with         = "packager-${var.ubuntu_codename}@infrahouse.com"
   repository_codename   = var.ubuntu_codename
   bucket_force_destroy  = true

--- a/variables.tf
+++ b/variables.tf
@@ -63,13 +63,31 @@ variable "architectures" {
   ]
 }
 
-variable "gpg_public_key" {
-  description = "Content of the GPG public key used for signing the repository. Note, you'll have to upload the key manually or with 'ih-s3-reprepro ... set-secret-value packager-key-focal ~/packager-key-focal'"
-  type        = string
+variable "gpg_public_keys" {
+  description = <<-EOT
+    Armored GPG public keys to publish for repository verification. They are concatenated into the
+    single published key object (DEB-GPG-KEY-<domain_name>); apt trusts a Release signed by any key
+    in the resulting keyring. During a signing-key rotation this holds both the outgoing and
+    incoming keys so clients trust a Release signed by either. Each list element is a full armored
+    public key block.
+
+    The private signing key(s) are uploaded out-of-band with
+    'ih-secrets set packager-key-<codename> ~/packager-key-<codename>'.
+  EOT
+  type        = list(string)
+
+  validation {
+    condition     = length(var.gpg_public_keys) >= 1
+    error_message = "gpg_public_keys must contain at least one armored GPG public key."
+  }
 }
 
 variable "gpg_sign_with" {
-  description = "Email of a packager user."
+  description = <<-EOT
+    Signing key identifier(s) for reprepro's SignWith in conf/distributions. Accepts a packager
+    email or one or more space-separated GPG key IDs / fingerprints. During a key rotation, set this
+    to both the outgoing and incoming key IDs to dual-sign the repository.
+  EOT
   type        = string
 }
 


### PR DESCRIPTION
## What

Replaces the single `gpg_public_key` (string) input with **`gpg_public_keys`** (`list(string)`, required). The keys are concatenated into the one published key object (`DEB-GPG-KEY-<domain_name>`); apt trusts a `Release` signed by **any** key in the resulting keyring.

## Why

This is the server-side half of zero-downtime **GPG signing-key rotation**. During a rotation overlap the published bundle holds **both** the outgoing and incoming public keys, so every apt client trusts a `Release` signed by either — no window where the repo is untrusted. Armored public keys concatenate, so there's no gpg tooling in the Terraform apply path; it's plain string joining (`join("\n", var.gpg_public_keys)`).

## Changes

- `variables.tf`: `gpg_public_key` (string) → `gpg_public_keys` (list(string)) with a `length >= 1` validation. Description covers the bundle/rotation intent and points the out-of-band private-key upload at `ih-secrets set`.
- `variables.tf`: refresh `gpg_sign_with` description — it accepts a packager email **or** space-separated GPG key IDs / fingerprints (dual-signing during rotation).
- `bucket.tf`: publish `join("\n", var.gpg_public_keys)`.
- Call sites + docs updated: `test_data/test_module`, `examples/basic`, README (terraform-docs), `docs/*.md`.

## Breaking change

Callers must change:
```hcl
gpg_public_key  = file("...")
# to
gpg_public_keys = [file("...")]
```

No version bump in this PR (per request).

## Notes

- Part of the broader GPG key rotation design; follow-ups land the client-side refresh in `terraform-aws-cloud-init` (fingerprint pin → set) and `puppet-code` (keyring convergence). The `ih-s3-reprepro export` support this relies on for re-signing shipped in infrahouse-toolkit #249.

🤖 Generated with [Claude Code](https://claude.com/claude-code)