### PR TITLE
docs: sync examples to 4.0.0 (batch key-gen, replication_region, bumpversion)

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -11,3 +11,19 @@ replace = version = "{new_version}"
 [bumpversion:file:locals.tf]
 search = module_version = "{current_version}"
 replace = module_version = "{new_version}"
+
+[bumpversion:file:docs/getting-started.md]
+search = version = "{current_version}"
+replace = version = "{new_version}"
+
+[bumpversion:file:docs/index.md]
+search = version = "{current_version}"
+replace = version = "{new_version}"
+
+[bumpversion:file:docs/examples.md]
+search = version = "{current_version}"
+replace = version = "{new_version}"
+
+[bumpversion:file:examples/basic/main.tf]
+search = version = "{current_version}"
+replace = version = "{new_version}"

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ module "debian_repo" {
   environment         = "production"
   repository_codename = "noble"
   domain_name         = "packages.example.com"
+  replication_region = "us-east-1"
   gpg_public_keys     = [
     file("./files/DEB-GPG-KEY-my-company")
   ]

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -13,12 +13,13 @@ module "oss_repo" {
     aws.ue1 = aws.aws-us-east-1
   }
   source  = "registry.infrahouse.com/infrahouse/debian-repo/aws"
-  version = "3.2.0"
+  version = "4.0.0"
 
   bucket_name         = "my-company-oss-noble"
   environment         = "production"
   repository_codename = "noble"
   domain_name         = "packages.example.com"
+  replication_region = "us-east-1"
   gpg_public_keys     = [
     file("./files/DEB-GPG-KEY-my-company")
   ]
@@ -38,12 +39,13 @@ module "private_repo" {
     aws.ue1 = aws.aws-us-east-1
   }
   source  = "registry.infrahouse.com/infrahouse/debian-repo/aws"
-  version = "3.2.0"
+  version = "4.0.0"
 
   bucket_name         = "my-company-internal-noble"
   environment         = "production"
   repository_codename = "noble"
   domain_name         = "internal-packages.example.com"
+  replication_region = "us-east-1"
   gpg_public_keys     = [
     file("./files/DEB-GPG-KEY-my-company")
   ]
@@ -66,12 +68,13 @@ module "repo_noble" {
     aws.ue1 = aws.aws-us-east-1
   }
   source  = "registry.infrahouse.com/infrahouse/debian-repo/aws"
-  version = "3.2.0"
+  version = "4.0.0"
 
   bucket_name         = "my-company-packages-noble"
   environment         = "production"
   repository_codename = "noble"
   domain_name         = "noble.packages.example.com"
+  replication_region = "us-east-1"
   gpg_public_keys     = [
     file("./files/DEB-GPG-KEY-my-company")
   ]
@@ -85,12 +88,13 @@ module "repo_jammy" {
     aws.ue1 = aws.aws-us-east-1
   }
   source  = "registry.infrahouse.com/infrahouse/debian-repo/aws"
-  version = "3.2.0"
+  version = "4.0.0"
 
   bucket_name         = "my-company-packages-jammy"
   environment         = "production"
   repository_codename = "jammy"
   domain_name         = "jammy.packages.example.com"
+  replication_region = "us-east-1"
   gpg_public_keys     = [
     file("./files/DEB-GPG-KEY-my-company")
   ]
@@ -110,12 +114,13 @@ module "debian_repo" {
     aws.ue1 = aws.aws-us-east-1
   }
   source  = "registry.infrahouse.com/infrahouse/debian-repo/aws"
-  version = "3.2.0"
+  version = "4.0.0"
 
   bucket_name         = "my-company-packages-noble"
   environment         = "production"
   repository_codename = "noble"
   domain_name         = "packages.example.com"
+  replication_region = "us-east-1"
   gpg_public_keys     = [
     file("./files/DEB-GPG-KEY-my-company")
   ]
@@ -153,12 +158,13 @@ module "debian_repo" {
     aws.ue1 = aws.aws-us-east-1
   }
   source  = "registry.infrahouse.com/infrahouse/debian-repo/aws"
-  version = "3.2.0"
+  version = "4.0.0"
 
   bucket_name         = "my-company-packages-noble"
   environment         = "production"
   repository_codename = "noble"
   domain_name         = "packages.example.com"
+  replication_region = "us-east-1"
   gpg_public_keys     = [
     file("./files/DEB-GPG-KEY-my-company")
   ]
@@ -179,12 +185,13 @@ module "debian_repo" {
     aws.ue1 = aws.aws-us-east-1
   }
   source  = "registry.infrahouse.com/infrahouse/debian-repo/aws"
-  version = "3.2.0"
+  version = "4.0.0"
 
   bucket_name         = "my-company-packages-noble"
   environment         = "production"
   repository_codename = "noble"
   domain_name         = "packages.example.com"
+  replication_region = "us-east-1"
   gpg_public_keys     = [
     file("./files/DEB-GPG-KEY-my-company")
   ]

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,24 +11,34 @@ This guide walks you through deploying your first Debian APT repository.
 
 ### GPG Key Pair
 
-You need a GPG key pair for signing packages. If you don't have one:
+You need a GPG key pair for signing packages. Generate it **non-interactively** (RSA-4096,
+2-year validity). Use a temporary passphrase for now — you'll align it to the Terraform-managed
+passphrase after the first apply (Step 3):
 
 ```bash
-gpg --full-gen-key
+gpg --batch --gen-key <<'EOF'
+%echo Generating packager key
+Key-Type: RSA
+Key-Length: 4096
+Subkey-Type: RSA
+Subkey-Length: 4096
+Name-Real: My Company Packager
+Name-Email: packager@example.com
+Expire-Date: 2y
+Passphrase: change-me-after-first-apply
+%commit
+EOF
 ```
-
-Choose:
-
-- Key type: RSA and RSA
-- Key size: 4096 bits
-- Validity: 2 years (recommended)
-- Name/email: e.g., "My Company Packager" / `packager@example.com`
 
 Export the public key:
 
 ```bash
 gpg --armor --export packager@example.com > ./files/DEB-GPG-KEY-my-company
 ```
+
+> **Rotating an existing repo's key** (not creating the first one)? Don't realign the passphrase
+> as in Step 3 — the passphrase secret already exists, so generate the new key **with** it and
+> publish both keys during an overlap. See the GPG key rotation runbook.
 
 ### Tools
 
@@ -62,12 +72,15 @@ module "debian_repo" {
     aws.ue1 = aws.aws-us-east-1
   }
   source  = "registry.infrahouse.com/infrahouse/debian-repo/aws"
-  version = "3.2.0"
+  version = "4.0.0"
 
   bucket_name         = "my-company-packages-noble"
   environment         = "production"
   repository_codename = "noble"
   domain_name         = "packages.example.com"
+  # Required: region for the S3 cross-region replication replica buckets.
+  # Must differ from the primary region (us-west-1 above).
+  replication_region  = "us-east-1"
   gpg_public_keys     = [
     file("./files/DEB-GPG-KEY-my-company")
   ]

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,12 +40,13 @@ module "debian_repo" {
     aws.ue1 = aws.aws-us-east-1
   }
   source  = "registry.infrahouse.com/infrahouse/debian-repo/aws"
-  version = "3.2.0"
+  version = "4.0.0"
 
   bucket_name         = "my-company-packages"
   environment         = "production"
   repository_codename = "noble"
   domain_name         = "packages.example.com"
+  replication_region = "us-east-1"
   gpg_public_keys     = [
     file("./files/DEB-GPG-KEY-my-company")
   ]

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -17,12 +17,13 @@ module "debian_repo" {
     aws.ue1 = aws.aws-us-east-1
   }
   source  = "registry.infrahouse.com/infrahouse/debian-repo/aws"
-  version = "3.2.0"
+  version = "4.0.0"
 
   bucket_name         = "my-company-packages-noble"
   environment         = "production"
   repository_codename = "noble"
   domain_name         = "packages.example.com"
+  replication_region  = "us-east-1"
   gpg_public_keys = [
     file("${path.module}/files/DEB-GPG-KEY-example")
   ]


### PR DESCRIPTION
Doc/example follow-ups to the `gpg_public_keys` change (4.0.0) that were missed at release time.

## Changes

- **`getting-started`**: interactive `gpg --full-gen-key` → non-interactive `gpg --batch --gen-key` (RSA-4096, `Expire-Date`), matching how keys are actually generated; adds a note distinguishing first-time passphrase realignment from rotation.
- **`replication_region` added to every module example.** 4.0.0 made it a **required** variable (no default), so the examples previously shown would fail `terraform plan` with "Missing required argument".
- **Fixed stale `version = "3.2.0"` pins → `4.0.0`** in `docs/` and `examples/basic`. They were frozen through the 3.3.0 and 4.0.0 releases because only `README.md` and `locals.tf` were registered in `.bumpversion.cfg`.
- **Registered** `docs/getting-started.md`, `docs/index.md`, `docs/examples.md`, and `examples/basic/main.tf` in `.bumpversion.cfg` so their pins bump automatically on future releases.

## Why

`gpg_public_keys` (4.0.0) is the server side of a zero-downtime GPG signing-key rotation; these are the doc consistency fixes surfaced while executing that rotation. No module code changes — docs, examples, and bumpversion config only.

## Verify

- `bumpversion --dry-run --allow-dirty --list patch` succeeds (all registered files' version strings found).
- Pre-commit (fmt, terraform-docs, trailing newline) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)